### PR TITLE
actually use port from config in connection

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -11,6 +11,10 @@ int main(int argc, char* argv[]) {
 
     Options opt(argv[1]);
     short port_num = opt.getPort();
+    if (port_num == -1) {
+        std::cerr << "Was not able to get port number from <config_file>.\n";
+        return 1;
+    }
     std::cout << "configured port: " << port_num << std::endl;
 
     Webserver ws;

--- a/src/main.cc
+++ b/src/main.cc
@@ -13,7 +13,7 @@ int main(int argc, char* argv[]) {
     short port_num = opt.getPort(argv[1]);
     std::cout << "configured port: " << port_num << std::endl;
 
-    Webserver ws;
+    Webserver ws(port_num);
     ws.run();
 
     return 0;

--- a/src/main.cc
+++ b/src/main.cc
@@ -9,8 +9,8 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
-    Options opt;
-    short port_num = opt.getPort(argv[1]);
+    Options opt(argv[1]);
+    short port_num = opt.getPort();
     std::cout << "configured port: " << port_num << std::endl;
 
     Webserver ws;

--- a/src/main.cc
+++ b/src/main.cc
@@ -17,7 +17,7 @@ int main(int argc, char* argv[]) {
     }
     std::cout << "configured port: " << port_num << std::endl;
 
-    Webserver ws;
+    Webserver ws(port_num);
     ws.run();
 
     return 0;

--- a/src/options.cc
+++ b/src/options.cc
@@ -2,12 +2,12 @@
 
 #include "options.h"
 
-short Options::getPort(const char* file_name) {
+Options::Options(const char* file_name) {
 	NginxConfigParser parser;
-    NginxConfig config;
+	parser.Parse(file_name, &config);
+}
 
-    parser.Parse(file_name, &config);
-
+short Options::getPort() {
     std::string p = config.statements_[0]->child_block_->statements_[0]->tokens_[1];
     return (short) std::stoi(p);
 }

--- a/src/options.cc
+++ b/src/options.cc
@@ -8,6 +8,16 @@ Options::Options(const char* file_name) {
 }
 
 short Options::getPort() {
-    std::string p = config.statements_[0]->child_block_->statements_[0]->tokens_[1];
-    return (short) std::stoi(p);
+	for (unsigned int i =0; i < config.statements_.size();i++) {
+		if (config.statements_[i]->tokens_[0] == "server") {
+			std::shared_ptr<NginxConfigStatement> temp_config = config.statements_[i];
+			for (unsigned int j = 0; j < temp_config->child_block_->statements_.size(); j++) {
+				if(temp_config->child_block_->statements_[j]->tokens_[0] == "listen") {
+					std::string port = temp_config->child_block_->statements_[j]->tokens_[1];
+					return (short) std::stoi(port);
+				}
+			}
+		}
+	}
+    return -1;
 }

--- a/src/options.h
+++ b/src/options.h
@@ -2,6 +2,9 @@
 
 class Options {
 	public:
-		Options() {}
-		short getPort(const char* file_name);
+		Options() {};
+		Options(const char* file_name);
+		short getPort();
+	private:
+		NginxConfig config;
 };

--- a/src/options.h
+++ b/src/options.h
@@ -2,7 +2,6 @@
 
 class Options {
 	public:
-		Options() {};
 		Options(const char* file_name);
 		short getPort();
 	private:

--- a/src/webserver.cc
+++ b/src/webserver.cc
@@ -5,17 +5,10 @@
 #include "webserver.h"
 
 using boost::asio::ip::tcp;
-//HTTP/1.1 200 OK\r\n
-//Content-length: 80\r\n
-//Content-type: "text/plain"\r\n
-//\r\n
-//body goes here
-//\r\n
 
 std::string processRawRequest(std::string& reqStr) {
-    std::string response = "HTTP/1.1 200 OK \r\n";
-    //response += "Content-length:" +reqStr.length() "\r\n";
-    response += "Content-type: \"text/plain\" \r\n";
+    std::string response = "HTTP/1.1 200 OK\r\n";
+    response += "Content-type:\"text/plain\"\r\n";
     response += "\r\n"+reqStr+"\r\n";
     return response;
 }

--- a/src/webserver.cc
+++ b/src/webserver.cc
@@ -5,9 +5,18 @@
 #include "webserver.h"
 
 using boost::asio::ip::tcp;
+//HTTP/1.1 200 OK\r\n
+//Content-length: 80\r\n
+//Content-type: "text/plain"\r\n
+//\r\n
+//body goes here
+//\r\n
 
 std::string processRawRequest(std::string& reqStr) {
-    std::string response = reqStr;
+    std::string response = "HTTP/1.1 200 OK \r\n";
+    //response += "Content-length:" +reqStr.length() "\r\n";
+    response += "Content-type: \"text/plain\" \r\n";
+    response += "\r\n"+reqStr+"\r\n";
     return response;
 }
 
@@ -55,4 +64,3 @@ void Webserver::run() {
         std::cerr << "Error: " << e.what() << std::endl;
     }
 }
-

--- a/src/webserver.cc
+++ b/src/webserver.cc
@@ -44,8 +44,7 @@ void processConnection(tcp::socket& socket) {
 void Webserver::run() {
     try {
         boost::asio::io_service io_service;
-        short port_num = 1234; // TODO: read from opt
-        tcp::acceptor acceptor(io_service, tcp::endpoint(tcp::v4(), port_num));
+        tcp::acceptor acceptor(io_service, tcp::endpoint(tcp::v4(), port_));
 
         while (true) {
             tcp::socket socket(io_service_);
@@ -57,3 +56,7 @@ void Webserver::run() {
         std::cerr << "Error: " << e.what() << std::endl;
     }
 }
+
+Webserver::Webserver(short port)
+: port_(port)
+{ }

--- a/src/webserver.cc
+++ b/src/webserver.cc
@@ -42,8 +42,7 @@ void processConnection(tcp::socket& socket) {
 void Webserver::run() {
     try {
         boost::asio::io_service io_service;
-        short port_num = 1234; // TODO: read from opt
-        tcp::acceptor acceptor(io_service, tcp::endpoint(tcp::v4(), port_num));
+        tcp::acceptor acceptor(io_service, tcp::endpoint(tcp::v4(), port_));
 
         while (true) {
             tcp::socket socket(io_service_);
@@ -56,3 +55,6 @@ void Webserver::run() {
     }
 }
 
+Webserver::Webserver(short port)
+: port_(port)
+{ }

--- a/src/webserver.h
+++ b/src/webserver.h
@@ -2,8 +2,10 @@
 
 class Webserver {
     public:
+        Webserver(short port);
         void run();
 
     private:
         boost::asio::io_service io_service_;
+        short port_;
 };


### PR DESCRIPTION
hook up `Options.getPort`'s result to `Webserver` instead of hardcoding the port number
TODO: pass entire opt struct to Webserver constructor when there are more options?