### PR TITLE
Fix quotes in HTTP response and use unsigned short for port number

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -10,7 +10,7 @@ int main(int argc, char* argv[]) {
     }
 
     Options opt(argv[1]);
-    short port_num = opt.getPort();
+    unsigned short port_num = opt.getPort();
     if (port_num == -1) {
         std::cerr << "Was not able to get port number from <config_file>.\n";
         return 1;

--- a/src/options.cc
+++ b/src/options.cc
@@ -7,14 +7,14 @@ Options::Options(const char* file_name) {
 	parser.Parse(file_name, &config);
 }
 
-short Options::getPort() {
+unsigned short Options::getPort() {
 	for (unsigned int i =0; i < config.statements_.size();i++) {
 		if (config.statements_[i]->tokens_[0] == "server") {
 			std::shared_ptr<NginxConfigStatement> temp_config = config.statements_[i];
 			for (unsigned int j = 0; j < temp_config->child_block_->statements_.size(); j++) {
 				if(temp_config->child_block_->statements_[j]->tokens_[0] == "listen") {
 					std::string port = temp_config->child_block_->statements_[j]->tokens_[1];
-					return (short) std::stoi(port);
+					return (unsigned short) std::stoi(port);
 				}
 			}
 		}

--- a/src/options.h
+++ b/src/options.h
@@ -3,7 +3,7 @@
 class Options {
 	public:
 		Options(const char* file_name);
-		short getPort();
+		unsigned short getPort();
 	private:
 		NginxConfig config;
 };

--- a/src/webserver.cc
+++ b/src/webserver.cc
@@ -8,7 +8,7 @@ using boost::asio::ip::tcp;
 
 std::string processRawRequest(std::string& reqStr) {
     std::string response = "HTTP/1.1 200 OK\r\n";
-    response += "Content-type:\"text/plain\"\r\n";
+    response += "Content-type: text/plain\r\n";
     response += "\r\n"+reqStr+"\r\n";
     return response;
 }


### PR DESCRIPTION
Fixes response not showing up inline in the browser and displaying negative port number when using a large port number.