### PR TITLE
Add Http response container

### DIFF
--- a/src/http_request.h
+++ b/src/http_request.h
@@ -24,9 +24,6 @@ enum HTTPRequestError {
     HTTPRequestError_Malformed,
     HTTPRequestError_BadVerb,
     HTTPRequestError_BadVersion,
-
-    HTTPRequestError_404_NotFound,
-    HTTPRequestError_500_InternalError,
 };
 
 class HTTPRequest {

--- a/src/http_request.h
+++ b/src/http_request.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <string>
 #include <unordered_map>
 

--- a/src/http_response.cc
+++ b/src/http_response.cc
@@ -1,0 +1,56 @@
+#include "http_response.h"
+
+const std::map<HTTPResponseCode, std::string> httpResponseCodeStrings =
+{
+    {HTTPResponseCode_200_OK, "200 OK"},
+
+    {HTTPResponseCode_400_BadRequest, "400 Bad Request"},
+    {HTTPResponseCode_401_Unauthorized, "401 Unauthorized"},
+    {HTTPResponseCode_403_Forbidden, "403 Forbidden"},
+    {HTTPResponseCode_404_NotFound, "404 Not Found"},
+
+    {HTTPResponseCode_500_InternalServerError, "500 Internal Server Error"},
+    {HTTPResponseCode_501_NotImplemented, "501 Not Implemented"},
+    {HTTPResponseCode_505_HTTPVersionNotSupported, "505 HTTP Version Not Supported"},
+};
+
+std::string HTTPResponse::makeResponseString() {
+    const std::string CRLF = "\r\n";
+    std::string resp = "HTTP/1.1 " + httpResponseCodeStrings.at(code_) + CRLF;
+
+    resp += "Content-Type: " + contentType_ + CRLF;
+    resp += "Connection: Closed" + CRLF;
+    resp += CRLF;
+    resp += content_;
+
+    return resp;
+}
+
+void HTTPResponse::setErrorFromHTTPRequestError(HTTPRequestError err) {
+    switch(err) {
+        case HTTPRequestError_None:
+            return;
+        case HTTPRequestError_Malformed:
+            return setError(HTTPResponseCode_400_BadRequest);
+        case HTTPRequestError_BadVerb:
+            return setError(HTTPResponseCode_400_BadRequest);
+        case HTTPRequestError_BadVersion:
+            return setError(HTTPResponseCode_505_HTTPVersionNotSupported);
+        case HTTPRequestError_404_NotFound:
+            return setError(HTTPResponseCode_404_NotFound);
+        case HTTPRequestError_500_InternalError:
+            return setError(HTTPResponseCode_500_InternalServerError);
+    }
+}
+
+void HTTPResponse::setError(HTTPResponseCode code) {
+    code_ = code;
+    content_ = "<html><body><h1>" + httpResponseCodeStrings.at(code) + "</body></html>";
+    contentType_ = "text/html";
+}
+
+void HTTPResponse::setErrorWithContent(HTTPResponseCode code, std::string content, std::string contentType) {
+    code_ = code;
+    content_ = content;
+    contentType_ = contentType;
+}

--- a/src/http_response.cc
+++ b/src/http_response.cc
@@ -36,10 +36,6 @@ void HTTPResponse::setErrorFromHTTPRequestError(HTTPRequestError err) {
             return setError(HTTPResponseCode_400_BadRequest);
         case HTTPRequestError_BadVersion:
             return setError(HTTPResponseCode_505_HTTPVersionNotSupported);
-        case HTTPRequestError_404_NotFound:
-            return setError(HTTPResponseCode_404_NotFound);
-        case HTTPRequestError_500_InternalError:
-            return setError(HTTPResponseCode_500_InternalServerError);
     }
 }
 

--- a/src/http_response.h
+++ b/src/http_response.h
@@ -1,0 +1,58 @@
+#pragma once
+#include <string>
+#include <map>
+#include "http_request.h"
+
+/*
+HTTP/1.1 200 OK
+Date: Sun, 18 Oct 2012 10:36:20 GMT
+Server: Apache/2.2.14 (Win32)
+Content-Length: 230
+Connection: Closed
+Content-Type: text/html; charset=iso-8859-1
+*/
+
+enum HTTPResponseCode {
+    HTTPResponseCode_200_OK,
+
+    HTTPResponseCode_400_BadRequest,
+    HTTPResponseCode_401_Unauthorized,
+    HTTPResponseCode_403_Forbidden,
+    HTTPResponseCode_404_NotFound,
+
+    HTTPResponseCode_500_InternalServerError,
+    HTTPResponseCode_501_NotImplemented,
+    HTTPResponseCode_505_HTTPVersionNotSupported,
+};
+
+extern const std::map<HTTPResponseCode, std::string> httpResponseCodeStrings;
+const std::string HTTPContentType_Plain = "text/plain";
+const std::string HTTPContentType_HTML = "text/html";
+
+class HTTPResponse {
+    public:
+        HTTPResponse() : code_(HTTPResponseCode_200_OK) {};
+
+        // set as a 200 OK
+        void okaySetContent(std::string content, std::string contentType) {
+            code_ = HTTPResponseCode_200_OK;
+            content_ = content;
+            contentType_ = contentType;
+        }
+
+        void setErrorFromHTTPRequestError(HTTPRequestError err);
+
+        // set as a non-200 response, and generate html error message
+        void setError(HTTPResponseCode code);
+
+        // set as a non-200 reponse, but give a custom content
+        void setErrorWithContent(HTTPResponseCode code, std::string content, std::string contentType);
+
+        std::string makeResponseString();
+
+    protected:
+        HTTPResponseCode code_;
+
+        std::string content_;
+        std::string contentType_;
+};

--- a/src/webserver.cc
+++ b/src/webserver.cc
@@ -4,21 +4,24 @@
 #include <boost/system/error_code.hpp>
 
 #include "http_request.h"
+#include "http_response.h"
 #include "webserver.h"
 
 using boost::asio::ip::tcp;
 
 std::string Webserver::processRawRequest(std::string& reqStr) {
     HTTPRequest req;
+    HTTPResponse resp;
+
     HTTPRequestError err = req.loadFromRawRequest(reqStr);
     if (err) {
         std::cout << "Error processing request" << std::endl;
+        resp.setErrorFromHTTPRequestError(err);
+        return resp.makeResponseString();
     }
 
-    std::string response = "HTTP/1.1 200 OK\r\n";
-    response += "Content-type: text/plain\r\n";
-    response += "\r\n"+reqStr+"\r\n";
-    return response;
+    resp.okaySetContent(reqStr, "text/plain");
+    return resp.makeResponseString();
 }
 
 inline std::string Webserver::readStrUntil(

--- a/tests/http_response_test.cc
+++ b/tests/http_response_test.cc
@@ -1,0 +1,53 @@
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "http_response.h"
+
+using ::testing::HasSubstr;
+
+TEST(HTTPResponseTest, makeResponseString) {
+    HTTPResponse resp;
+
+    resp.okaySetContent("Hello", HTTPContentType_Plain);
+
+    std::string s = resp.makeResponseString();
+
+    EXPECT_THAT(s, HasSubstr("HTTP/1.1 200 OK\r\n"));
+    EXPECT_THAT(s, HasSubstr("Content-Type: text/plain\r\n"));
+    EXPECT_THAT(s, HasSubstr("Hello"));
+}
+
+TEST(HTTPResponseTest, setError) {
+    HTTPResponse resp;
+
+    resp.setError(HTTPResponseCode_500_InternalServerError);
+
+    std::string s = resp.makeResponseString();
+
+    EXPECT_THAT(s, HasSubstr("HTTP/1.1 500 Internal Server Error\r\n"));
+    EXPECT_THAT(s, HasSubstr("Content-Type:")); // any content type, as long as header exists
+    EXPECT_THAT(s, HasSubstr("\r\n\r\n")); // has header end
+}
+
+TEST(HTTPResponseTest, setErrorWithContent) {
+    HTTPResponse resp;
+
+    resp.setErrorWithContent(HTTPResponseCode_404_NotFound, "Custom 404", HTTPContentType_Plain);
+
+    std::string s = resp.makeResponseString();
+
+    EXPECT_THAT(s, HasSubstr("HTTP/1.1 404 Not Found\r\n"));
+    EXPECT_THAT(s, HasSubstr("Content-Type: text/plain"));
+    EXPECT_THAT(s, HasSubstr("\r\n\r\nCustom 404"));
+}
+
+TEST(HTTPResponseTest, setErrorFromHTTPRequestError) {
+    HTTPResponse resp;
+
+    resp.setErrorFromHTTPRequestError(HTTPRequestError_Malformed);
+
+    std::string s = resp.makeResponseString();
+
+    EXPECT_THAT(s, HasSubstr("HTTP/1.1 400 Bad Request\r\n"));
+    EXPECT_THAT(s, HasSubstr("Content-Type:")); // any content type, as long as header exists
+    EXPECT_THAT(s, HasSubstr("\r\n\r\n")); // has header end
+}

--- a/tests/webserver_test.cc
+++ b/tests/webserver_test.cc
@@ -50,7 +50,7 @@ TEST(WebserverTest, processRawRequest) {
     std::string resp = ws.processRawRequest(req);
 
     EXPECT_THAT(resp, HasSubstr("HTTP/1.1 200 OK\r\n"));
-    EXPECT_THAT(resp, HasSubstr("Content-type: text/plain\r\n"));
+    EXPECT_THAT(resp, HasSubstr("Content-Type: text/plain\r\n"));
 
     // For now, we're expecting it to echo the request
     EXPECT_THAT(resp, HasSubstr(req));


### PR DESCRIPTION
adds container for http responses

* easily add content and set as 200 OK
* generate simple html error pages for non-200 responses

TODO: support binary content blobs which set the `Content-Length` header?