### PR TITLE
implement Module path matching

### DIFF
--- a/src/echo_module.cc
+++ b/src/echo_module.cc
@@ -3,8 +3,8 @@
 
 const std::string EchoModule::typeString = "echo";
 
-Module* EchoModule::createFromParameters(std::shared_ptr<std::map<std::string, std::string>> params) {
-    Module* mod = new EchoModule();
+Module* EchoModule::createFromParameters(std::string path, std::shared_ptr<std::map<std::string, std::string>> params) {
+    Module* mod = new EchoModule(path);
     return mod;
 }
 

--- a/src/echo_module.h
+++ b/src/echo_module.h
@@ -3,7 +3,9 @@
 
 class EchoModule : public Module {
     public:
+        EchoModule(std::string path) : Module(path) {}
         const static std::string typeString;
-        static Module* createFromParameters(std::shared_ptr<std::map<std::string, std::string>> params);
+        static Module* createFromParameters(std::string path, std::shared_ptr<std::map<std::string, std::string>> params);
+
         virtual bool handleRequest(const HTTPRequest& req, HTTPResponse* resp);
 };

--- a/src/module.cc
+++ b/src/module.cc
@@ -19,7 +19,7 @@ Module* createModuleFromParameters(std::shared_ptr<std::map<std::string, std::st
     }
 
     if (typeParam->second == EchoModule::typeString) {
-        Module* mod = EchoModule::createFromParameters(params);
+        Module* mod = EchoModule::createFromParameters(pathParam->second, params);
         return mod;
     } else {
         std::cerr << "Unknown module type \"" << typeParam->second << "\"." << std::endl;
@@ -28,6 +28,29 @@ Module* createModuleFromParameters(std::shared_ptr<std::map<std::string, std::st
     return nullptr;
 }
 
-bool Module::matchesRequestPath(const std::string& str) const {
-    return false; //TODO
+/* determine if a request's path matches this Module's configured path.
+ * path format is purely prefixed based, with an exception for trailing '/':
+ *   "/foo" would match "/foo", "/foo/bar", AND "/foobar"
+ *      translates to regex: "/foo.*"
+ *   "/foo/" would match "/foo", "/foo/bar", but NOT "/foobar"
+ *      translates to regex: "/foo/?.*"
+ * This is because "/foo" and "/foo/" should act identically in terms of file requests.
+ * Module subclasses can override this method if they have other considerations.
+ */
+bool Module::matchesRequestPath(const std::string& reqPath) const {
+    if (reqPath.size() < path_.size() - 1) return false;
+
+    size_t pathSize = path_.size();
+    if ((reqPath.size() == path_.size() - 1)
+            && (path_.size() > 1) && (path_[path_.size()-1] == '/')) {
+        pathSize--;
+    }
+
+    for (int i = 0; i < pathSize; ++i) {
+        if (path_[i] != reqPath[i]) {
+            return false;
+        }
+    }
+
+    return true;
 }

--- a/src/module.h
+++ b/src/module.h
@@ -8,11 +8,13 @@
 
 class Module {
     public:
+        Module(std::string path) : path_(path) {}
         virtual ~Module() = default;
         virtual bool handleRequest(const HTTPRequest& req, HTTPResponse* resp) = 0;
         virtual bool matchesRequestPath(const std::string& str) const;
 
     private:
+        std::string path_;
         std::shared_ptr<std::map<std::string, std::string>> moduleParameters;
 };
 

--- a/tests/echo_module_test.cc
+++ b/tests/echo_module_test.cc
@@ -27,7 +27,7 @@ TEST(EchoModuleTest, createEchoModule) {
             {"path", "/foo"},
             });
 
-    std::unique_ptr<Module> mod(EchoModule::createFromParameters(paramMap));
+    std::unique_ptr<Module> mod(EchoModule::createFromParameters("/foo", paramMap));
     ASSERT_NE(mod, nullptr);
 }
 
@@ -41,7 +41,7 @@ class EchoModuleTester : public ::testing::Test {
                     {"path", "/foo"},
                     });
 
-            std::unique_ptr<Module> mod(EchoModule::createFromParameters(paramMap));
+            std::unique_ptr<Module> mod(EchoModule::createFromParameters("/foo", paramMap));
             return mod;
         }
 };

--- a/tests/module_test.cc
+++ b/tests/module_test.cc
@@ -1,5 +1,6 @@
 #include "gtest/gtest.h"
 #include "module.h"
+#include "echo_module.h"
 #include <map>
 #include <memory>
 #include <string>
@@ -49,3 +50,49 @@ TEST(ModuleTest, createModule_noPath) {
     Module* mod = createModuleFromParameters(paramMap);
     ASSERT_EQ(mod, nullptr);
 }
+
+TEST(ModuleTest, matchesRequestPath) {
+    Module* mod = EchoModule::createFromParameters("/foo/bar", nullptr);
+    ASSERT_NE(mod, nullptr);
+
+    EXPECT_TRUE(mod->matchesRequestPath("/foo/bar"));
+    EXPECT_TRUE(mod->matchesRequestPath("/foo/bar/"));
+    EXPECT_TRUE(mod->matchesRequestPath("/foo/bar/baz.png"));
+    EXPECT_TRUE(mod->matchesRequestPath("/foo/bar/flom/baz.png"));
+
+    EXPECT_FALSE(mod->matchesRequestPath("/bad/"));
+    EXPECT_FALSE(mod->matchesRequestPath("/foo/"));
+    EXPECT_FALSE(mod->matchesRequestPath("/foo/bad"));
+    EXPECT_FALSE(mod->matchesRequestPath("/foo/bad/baz"));
+
+    EXPECT_TRUE(mod->matchesRequestPath("/foo/barnyard"));
+}
+
+TEST(ModuleTest, matchesRequestPathTrailingSlash) {
+    Module* mod = EchoModule::createFromParameters("/foo/bar/", nullptr);
+    ASSERT_NE(mod, nullptr);
+
+    EXPECT_TRUE(mod->matchesRequestPath("/foo/bar"));
+    EXPECT_TRUE(mod->matchesRequestPath("/foo/bar/"));
+    EXPECT_TRUE(mod->matchesRequestPath("/foo/bar/baz.png"));
+    EXPECT_TRUE(mod->matchesRequestPath("/foo/bar/flom/baz.png"));
+
+    EXPECT_FALSE(mod->matchesRequestPath("/bad/"));
+    EXPECT_FALSE(mod->matchesRequestPath("/foo/"));
+    EXPECT_FALSE(mod->matchesRequestPath("/foo/bad"));
+    EXPECT_FALSE(mod->matchesRequestPath("/foo/bad/"));
+    EXPECT_FALSE(mod->matchesRequestPath("/foo/bad/baz"));
+
+    EXPECT_FALSE(mod->matchesRequestPath("/foo/barnyard"));
+}
+
+TEST(ModuleTest, matchesRequestPathCatchall) {
+    Module* mod = EchoModule::createFromParameters("/", nullptr);
+    ASSERT_NE(mod, nullptr);
+
+    EXPECT_TRUE(mod->matchesRequestPath("/"));
+    EXPECT_TRUE(mod->matchesRequestPath("/foo"));
+    EXPECT_TRUE(mod->matchesRequestPath("/foo.bar"));
+    EXPECT_TRUE(mod->matchesRequestPath("/foo/bar"));
+}
+


### PR DESCRIPTION
Implements the ability for a module to determine if it can handle a given request from it's `path_` parameter.

Are there any pathological cases that the matcher doesn't work for?