### PR TITLE
hold options in webserver

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -17,7 +17,7 @@ int main(int argc, char* argv[]) {
     unsigned short port_num = opt.port;
     std::cout << "configured port: " << port_num << std::endl;
 
-    Webserver ws(port_num);
+    Webserver ws(&opt);
     ws.run();
 
     return 0;

--- a/src/options.h
+++ b/src/options.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <vector>
 
 #include "module.h"

--- a/src/webserver.cc
+++ b/src/webserver.cc
@@ -82,7 +82,7 @@ bool Webserver::acceptConnection(tcp::acceptor& acceptor, tcp::socket& socket) {
 void Webserver::run() {
     try {
         boost::asio::io_service io_service;
-        tcp::acceptor acceptor(io_service, tcp::endpoint(tcp::v4(), port_));
+        tcp::acceptor acceptor(io_service, tcp::endpoint(tcp::v4(), opt_->port));
 
         while (true) {
             tcp::socket socket(io_service_);
@@ -98,6 +98,6 @@ void Webserver::run() {
     }
 }
 
-Webserver::Webserver(unsigned short port)
-: port_(port)
+Webserver::Webserver(Options* opt)
+: opt_(opt)
 { }

--- a/src/webserver.h
+++ b/src/webserver.h
@@ -1,8 +1,10 @@
+#pragma once
 #include <boost/asio.hpp>
+#include "options.h"
 
 class Webserver {
     public:
-        Webserver(unsigned short port);
+        Webserver(Options* opt);
         virtual void run();
 
         virtual std::string readStrUntil(
@@ -18,6 +20,6 @@ class Webserver {
 
     private:
         boost::asio::io_service io_service_;
-        unsigned short port_;
+        Options* opt_;
 };
 

--- a/tests/webserver_test.cc
+++ b/tests/webserver_test.cc
@@ -1,5 +1,6 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
+#include "options.h"
 #include "webserver.h"
 #include <sstream>
 
@@ -15,8 +16,8 @@ class MockWebserverRun : public Webserver {
         MOCK_METHOD2(acceptConnection, bool(tcp::acceptor& acceptor, tcp::socket& sock));
         MOCK_METHOD1(processConnection, void(tcp::socket& sock));
 
-        MockWebserverRun(unsigned short port)
-            : Webserver(port)
+        MockWebserverRun(Options* opt)
+            : Webserver(opt)
         { }
 };
 
@@ -31,13 +32,15 @@ class MockWebserverProcessConnection : public Webserver {
         MOCK_METHOD1(logConnectionDetails, void(tcp::socket& socket));
         MOCK_METHOD2(writeResponseString, void(boost::asio::ip::tcp::socket& socket, const std::string& s));
 
-        MockWebserverProcessConnection(unsigned short port)
-            : Webserver(port)
+        MockWebserverProcessConnection(Options* opt)
+            : Webserver(opt)
         { }
 };
 
 TEST(WebserverTest, processRawRequest) {
-    Webserver ws(8080);
+    Options opts;
+    opts.port = 8080;
+    Webserver ws(&opts);
 
     std::string req = (
             "GET / HTTP/1.1\r\n"
@@ -58,7 +61,9 @@ TEST(WebserverTest, processRawRequest) {
 
 
 TEST(WebserverTest, acceptConnections) {
-    MockWebserverRun webserver(8080);
+    Options opts;
+    opts.port = 8080;
+    MockWebserverRun webserver(&opts);
 
     EXPECT_CALL(webserver, acceptConnection(_, _))
         .Times(3)
@@ -73,7 +78,9 @@ TEST(WebserverTest, acceptConnections) {
 }
 
 TEST(WebserverTest, processConnectionTest) {
-    MockWebserverProcessConnection webserver(8080);
+    Options opts;
+    opts.port = 8080;
+    MockWebserverProcessConnection webserver(&opts);
 
     EXPECT_CALL(webserver, logConnectionDetails(_)).Times(1);
 


### PR DESCRIPTION
We'll need the `Options` object so that the main request handler can dispatch to the correct Module, which is contained in `Options`.

Also added some `#pragma once`s to fix import cycles.