### PR TITLE
Use correct path when handling static file requests

### DIFF
--- a/example_config
+++ b/example_config
@@ -2,11 +2,11 @@ server {
 	port =  8080;
 	module {
 		type = echo;
-		path = "/echo";
+		path = /echo;
 	}
 	module {
 		type = static;
-		path = "/static";
+		path = /static;
 		filebase = testFiles1;
 	}
 }

--- a/src/module.h
+++ b/src/module.h
@@ -13,7 +13,7 @@ class Module {
         virtual bool handleRequest(const HTTPRequest& req, HTTPResponse* resp) = 0;
         virtual bool matchesRequestPath(const std::string& str) const;
 
-    private:
+    protected:
         std::string path_;
         std::shared_ptr<std::map<std::string, std::string>> moduleParameters;
 };

--- a/src/static_module.cc
+++ b/src/static_module.cc
@@ -29,7 +29,7 @@ StaticModule::StaticModule(string path, string filebase)
 { }
 
 bool StaticModule::handleRequest(const HTTPRequest& req, HTTPResponse* resp) {
-    std::cout << "  > request being handled by static module" << std::endl;
+    std::cout << "  > request being handled by static module (path: " << path_ << ")" << std::endl;
     string reqPath = req.getPath().substr(path_.size());
 
     // TODO: sanitize path: filter out %20, make sure '..' won't go up a directory

--- a/src/static_module.cc
+++ b/src/static_module.cc
@@ -29,16 +29,19 @@ StaticModule::StaticModule(string path, string filebase)
 { }
 
 bool StaticModule::handleRequest(const HTTPRequest& req, HTTPResponse* resp) {
-    string path = req.getPath();
+    std::cout << "  > request being handled by static module" << std::endl;
+    string reqPath = req.getPath().substr(path_.size());
 
     // TODO: sanitize path: filter out %20, make sure '..' won't go up a directory
 
     string filepath;
     if (filebase_[filebase_.size()-1] == '/') {
-        filepath = filebase_ + req.getPath().substr(1);
+        filepath = filebase_ + reqPath.substr(1);
     } else {
-        filepath = filebase_ + req.getPath();
+        filepath = filebase_ + reqPath;
     }
+
+    std::cout << "  > looking for '" << req.getPath() << "' (" << reqPath << ")" << " in " << filepath << std::endl;
 
     FileLoader fl;
 
@@ -62,6 +65,6 @@ bool StaticModule::handleRequest(const HTTPRequest& req, HTTPResponse* resp) {
             return true;
     }
 
-    resp->okaySetContent(req.getRawRequest(), HTTPContentType_Plain);
+    resp->setError(HTTPResponseCode_500_InternalServerError);
     return false;
 }

--- a/tests/static_module_test.cc
+++ b/tests/static_module_test.cc
@@ -67,7 +67,7 @@ class StaticModuleTester : public ::testing::Test {
                     {"filebase", filebase},
                     });
 
-            std::unique_ptr<Module> mod(StaticModule::createFromParameters("/foo", paramMap));
+            std::unique_ptr<Module> mod(StaticModule::createFromParameters("/static", paramMap));
             return mod;
         }
 };
@@ -76,7 +76,7 @@ TEST_F(StaticModuleTester, handleRequest) {
     auto mod = makeTestStaticModule("testFiles1");
 
     std::string reqStr = (
-            "GET /page.html HTTP/1.1\r\n"
+            "GET /static/page.html HTTP/1.1\r\n"
             "User-Agent: Mozilla/1.0\r\n"
             "\r\n"
             );
@@ -103,7 +103,7 @@ TEST_F(StaticModuleTester, handleRequestNoFile) {
     auto mod = makeTestStaticModule("testFiles1");
 
     std::string reqStr = (
-            "GET /cannot/find/this/file HTTP/1.1\r\n"
+            "GET /static/cannot/find/this/file HTTP/1.1\r\n"
             "User-Agent: Mozilla/1.0\r\n"
             "\r\n"
             );
@@ -123,7 +123,7 @@ TEST_F(StaticModuleTester, handleRequestTrailingSlash) {
     auto mod = makeTestStaticModule("testFiles1/");
 
     std::string reqStr = (
-            "GET /page.html HTTP/1.1\r\n"
+            "GET /static/page.html HTTP/1.1\r\n"
             "User-Agent: Mozilla/1.0\r\n"
             "\r\n"
             );
@@ -146,7 +146,7 @@ TEST_F(StaticModuleTester, handleRequestImageType) {
     auto mod = makeTestStaticModule("testFiles1/");
 
     std::string reqStr = (
-            "GET /cat.gif HTTP/1.1\r\n"
+            "GET /static/cat.gif HTTP/1.1\r\n"
             "User-Agent: Mozilla/1.0\r\n"
             "\r\n"
             );


### PR DESCRIPTION
When handling a request in a static module, we need to use the part of the request path after what the module's path specifies. Also fixes test that didn't test this behavior.