### PR TITLE
use static handler registration

### DIFF
--- a/src/echo_handler.h
+++ b/src/echo_handler.h
@@ -11,3 +11,5 @@ class EchoHandler : public RequestHandler {
 
         virtual ~EchoHandler() = default;
 };
+
+REGISTER_REQUEST_HANDLER(EchoHandler);

--- a/src/register_handler.cc
+++ b/src/register_handler.cc
@@ -1,0 +1,3 @@
+#include "register_handler.h"
+
+std::map<std::string, RequestHandler* (*)(void)>* request_handler_builders = nullptr;

--- a/src/register_handler.h
+++ b/src/register_handler.h
@@ -4,8 +4,10 @@
 #include <string>
 
 class RequestHandler; // forward declaration
+// this map enables RequestHandler::CreateByName
 extern std::map<std::string, RequestHandler* (*)(void)>* request_handler_builders;
 
+// REGISTER_REQUEST_HANDLER constructs this to statically add new handlers to map
 template<typename T>
 class RequestHandlerRegisterer {
     public:

--- a/src/register_handler.h
+++ b/src/register_handler.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <map>
+#include <memory>
+#include <string>
+
+class RequestHandler; // forward declaration
+extern std::map<std::string, RequestHandler* (*)(void)>* request_handler_builders;
+
+template<typename T>
+class RequestHandlerRegisterer {
+    public:
+        RequestHandlerRegisterer(const std::string& type) {
+            if (request_handler_builders == nullptr) {
+                request_handler_builders = new std::map<std::string, RequestHandler* (*)(void)>;
+            }
+            (*request_handler_builders)[type] = RequestHandlerRegisterer::Create;
+        }
+        static RequestHandler* Create() {
+            return new T;
+        }
+};

--- a/src/request_handler.cc
+++ b/src/request_handler.cc
@@ -3,12 +3,13 @@
 #include <cstring>
 
 RequestHandler* RequestHandler::CreateByName(const char* type) {
-    // TODO(evan): use static registeration
-    std::string typeStr(type, std::strlen(type));
-    if (typeStr == "EchoHandler") {
-        return new EchoHandler();
-    } else {
-        std::cerr << "Unknown handler name '" << typeStr << "'" << std::endl;
+    if ( ! request_handler_builders) {
+        std::cerr << "No Request Handlers registered!" << std::endl;
+    }
+    const auto type_and_builder = request_handler_builders->find(type);
+    if (type_and_builder == request_handler_builders->end()) {
+        std::cerr << "handler type '" << type << "' not registered." << std::endl;
         return nullptr;
     }
+    return (*type_and_builder->second)();
 }

--- a/src/request_handler.h
+++ b/src/request_handler.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <string>
 #include "config_parser.h"
+#include "register_handler.h"
 
 
 // For the Request and Response classes, you need to implement the methods
@@ -96,4 +97,7 @@ class RequestHandler {
 
         virtual ~RequestHandler() = default;
 };
+
+#define REGISTER_REQUEST_HANDLER(ClassName) \
+  static RequestHandlerRegisterer<ClassName> ClassName##__registerer(#ClassName)
 

--- a/tests/request_handler_test.cc
+++ b/tests/request_handler_test.cc
@@ -1,0 +1,10 @@
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "request_handler.h"
+#include <memory>
+
+TEST(RequestHandlerTest, unknownHandler) {
+    std::unique_ptr<RequestHandler> handler(RequestHandler::CreateByName("DefinitelyNotARealHandler"));
+    ASSERT_EQ(handler, nullptr);
+}
+


### PR DESCRIPTION
Instead of manually checking the name of a request handler, you can simply use `REGISTER_REQUEST_HANDLER(HandlerName)`. This eases installation of new handlers.