### PR TITLE
Basic Status Handler

### DIFF
--- a/src/echo_handler.h
+++ b/src/echo_handler.h
@@ -10,6 +10,10 @@ class EchoHandler : public RequestHandler {
                 Response* response);
 
         virtual ~EchoHandler() = default;
+
+        virtual std::string type() const {
+            return "EchoHandler";
+        }
 };
 
 REGISTER_REQUEST_HANDLER(EchoHandler);

--- a/src/request_handler.h
+++ b/src/request_handler.h
@@ -77,6 +77,7 @@ class RequestHandler {
     public:
         enum Status {
             OK = 0,
+            Error,
         };
 
         // Initializes the handler. Returns a response code indicating success or

--- a/src/request_handler.h
+++ b/src/request_handler.h
@@ -96,6 +96,9 @@ class RequestHandler {
         static RequestHandler* CreateByName(const char* type);
 
         virtual ~RequestHandler() = default;
+
+        // get type of request handler
+        virtual std::string type() const = 0;
 };
 
 #define REGISTER_REQUEST_HANDLER(ClassName) \

--- a/src/status_handler.cc
+++ b/src/status_handler.cc
@@ -14,10 +14,21 @@ RequestHandler::Status StatusHandler::HandleRequest(const Request& req, Response
         return RequestHandler::Error;
     }
 
+    auto opt = ws->options();
+    std::string handlersStr;
+    for (auto h : opt->handlerMap) {
+        handlersStr += "<tr><td>" + h.first + "</td><td>" + h.second->type() + "</td></tr>";
+    }
+
     std::string html = (
             "<html>"
             "  <body>"
-            "    Webserver Status"
+            "    <h1>Webserver Status</h1>"
+            "    <h2>Registered handlers:</h2>"
+            "    <table style=\"font-family: monospace\">"
+            "      <tr><th>Path</th><th>Handler Type</th></tr>"
+            + handlersStr +
+            "    </table>"
             "  <body>"
             "</html>"
             );

--- a/src/status_handler.cc
+++ b/src/status_handler.cc
@@ -1,0 +1,13 @@
+#include "status_handler.h"
+#include <iostream>
+
+RequestHandler::Status StatusHandler::Init(const std::string& uri_prefix, const NginxConfig& config) {
+    return RequestHandler::OK;
+}
+
+RequestHandler::Status StatusHandler::HandleRequest(const Request& req, Response* resp) {
+    resp->SetStatus(Response::code_200_OK);
+    resp->SetBody("<html><body>Webserver Status<body></html>");
+    resp->AddHeader("Content-Type", "text/html");
+    return RequestHandler::OK;
+}

--- a/src/status_handler.cc
+++ b/src/status_handler.cc
@@ -1,4 +1,5 @@
 #include "status_handler.h"
+#include "webserver.h"
 #include <iostream>
 
 RequestHandler::Status StatusHandler::Init(const std::string& uri_prefix, const NginxConfig& config) {
@@ -6,8 +7,23 @@ RequestHandler::Status StatusHandler::Init(const std::string& uri_prefix, const 
 }
 
 RequestHandler::Status StatusHandler::HandleRequest(const Request& req, Response* resp) {
+    Webserver* ws = Webserver::instance;
+    if ( ! ws) {
+        std::cerr << "StatusHandler failed: No global webserver instance." << std::endl;
+        resp->SetStatus(Response::code_404_not_found);
+        return RequestHandler::Error;
+    }
+
+    std::string html = (
+            "<html>"
+            "  <body>"
+            "    Webserver Status"
+            "  <body>"
+            "</html>"
+            );
+
     resp->SetStatus(Response::code_200_OK);
-    resp->SetBody("<html><body>Webserver Status<body></html>");
+    resp->SetBody(html);
     resp->AddHeader("Content-Type", "text/html");
     return RequestHandler::OK;
 }

--- a/src/status_handler.h
+++ b/src/status_handler.h
@@ -15,3 +15,5 @@ class StatusHandler : public RequestHandler {
             return "StatusHandler";
         }
 };
+
+REGISTER_REQUEST_HANDLER(StatusHandler);

--- a/src/status_handler.h
+++ b/src/status_handler.h
@@ -10,4 +10,8 @@ class StatusHandler : public RequestHandler {
                 Response* response);
 
         virtual ~StatusHandler() = default;
+
+        virtual std::string type() const {
+            return "StatusHandler";
+        }
 };

--- a/src/status_handler.h
+++ b/src/status_handler.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "request_handler.h"
+
+class StatusHandler : public RequestHandler {
+    public:
+        virtual Status Init(const std::string& uri_prefix,
+                const NginxConfig& config);
+
+        virtual Status HandleRequest(const Request& request,
+                Response* response);
+
+        virtual ~StatusHandler() = default;
+};

--- a/src/webserver.cc
+++ b/src/webserver.cc
@@ -118,6 +118,9 @@ void Webserver::run() {
     }
 }
 
+Webserver* Webserver::instance = nullptr;
 Webserver::Webserver(Options* opt)
 : opt_(opt)
-{ }
+{
+    Webserver::instance = this;
+}

--- a/src/webserver.h
+++ b/src/webserver.h
@@ -5,6 +5,10 @@
 
 class Webserver {
     public:
+        // faux singleton: Webserver::instance stores the most recently constructed webserver.
+        // Multiple webserver instances are allowed, but handlers that rely on global status will see the most recent.
+        static Webserver* instance;
+
         Webserver(Options* opt);
         virtual void run();
 
@@ -19,6 +23,10 @@ class Webserver {
         virtual std::string processRawRequest(std::string& reqStr);
         virtual void writeResponseString(boost::asio::ip::tcp::socket& socket, const std::string& s);
         virtual RequestHandler* matchRequestWithHandler(const Request& req);
+
+        virtual std::map<std::string, RequestHandler*>* handlers() const {
+            return &opt_->handlerMap;
+        }
 
     private:
         boost::asio::io_service io_service_;

--- a/src/webserver.h
+++ b/src/webserver.h
@@ -24,8 +24,8 @@ class Webserver {
         virtual void writeResponseString(boost::asio::ip::tcp::socket& socket, const std::string& s);
         virtual RequestHandler* matchRequestWithHandler(const Request& req);
 
-        virtual std::map<std::string, RequestHandler*>* handlers() const {
-            return &opt_->handlerMap;
+        virtual Options* options() const {
+            return opt_;
         }
 
     private:

--- a/tests/status_handler_test.cc
+++ b/tests/status_handler_test.cc
@@ -1,0 +1,83 @@
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "echo_handler.h"
+#include "status_handler.h"
+#include "options.h"
+#include "webserver.h"
+#include <map>
+#include <memory>
+#include <string>
+
+using std::map;
+using std::string;
+using ::testing::HasSubstr;
+
+TEST(RequestHandlerTest, createStatusHandler) {
+    std::unique_ptr<RequestHandler> handler(RequestHandler::CreateByName("StatusHandler"));
+    ASSERT_NE(handler, nullptr);
+}
+
+TEST(StatusHandlerTest, initHandler) {
+    std::unique_ptr<RequestHandler> handler(new StatusHandler());
+    ASSERT_NE(handler, nullptr);
+
+    NginxConfig config;
+    RequestHandler::Status status = handler->Init("/foo", config);
+    EXPECT_EQ(status, RequestHandler::OK);
+}
+
+class StatusHandlerTestF : public ::testing::Test {
+    protected:
+        // given an array of path prefix to RequestHandler*, initialize a webserver instance
+        virtual bool createServerFromHandlers(std::vector<std::pair<std::string, RequestHandler*>> handlers) {
+            opts_ = new Options();
+            opts_->port = 8080;
+            NginxConfig config;
+            for (auto& h : handlers) {
+                h.second->Init(h.first, config);
+                opts_->handlerMap[h.first] = h.second;
+            }
+            ws_ = new Webserver(opts_);
+        }
+
+        virtual void Teardown() {
+            delete ws_;
+            delete opts_;
+        }
+
+        Options* opts_;
+        Webserver* ws_;
+};
+
+TEST_F(StatusHandlerTestF, handleRequest) {
+    RequestHandler* h1 = new EchoHandler();
+    RequestHandler* h2 = new EchoHandler();
+    RequestHandler* s1 = new StatusHandler();
+    createServerFromHandlers({
+            {"/foo", h1},
+            {"/baz", h2},
+            {"/status", s1},
+            });
+
+
+    auto req = Request::Parse(
+            "GET /status HTTP/1.1\r\n"
+            "\r\n"
+            );
+
+    Response resp;
+    ASSERT_EQ(s1->HandleRequest(*req, &resp), RequestHandler::OK);
+
+    string respStr = resp.ToString();
+    EXPECT_THAT(respStr, HasSubstr("200 OK"));
+    EXPECT_THAT(respStr, HasSubstr("/foo"));
+    EXPECT_THAT(respStr, HasSubstr("/baz"));
+    EXPECT_THAT(respStr, HasSubstr("EchoHandler"));
+    EXPECT_THAT(respStr, HasSubstr("/status"));
+    EXPECT_THAT(respStr, HasSubstr("StatusHandler"));
+
+    delete h1;
+    delete h2;
+    delete s1;
+}
+


### PR DESCRIPTION
Add a Status Request Handler. Currently this displays what handlers have been registered. Still TODO in another PR is to show a record of previous requested URLs and statuses. That change will require a thread-safe multi-map counter, so I figured that can be a separate PR.

Note: the status handler must query the webserver for information. It seemed like a bad idea to use a singleton, in case future use requires multiple server instances. So the status handler only looks for the most recent Webserver Instance in a global. Even though we would possibly support multiple instances, we don't test for it.