### PR TITLE
fix not found handler not providing type()

### DIFF
--- a/src/not_found_handler.h
+++ b/src/not_found_handler.h
@@ -10,6 +10,10 @@ class NotFoundHandler : public RequestHandler {
                 Response* response);
 
         virtual ~NotFoundHandler() = default;
+
+        virtual std::string type() const {
+            return "NotFoundHandler";
+        }
 };
 
 REGISTER_REQUEST_HANDLER(NotFoundHandler);


### PR DESCRIPTION
From merging both NotFoundHandler and StatusHandler, NotFoundHandler didn't specify a `type()`. This quick change fixes that and will make the build pass.