### PR TITLE
make static handler use NotFoundHandler for not found files

### DIFF
--- a/src/static_handler.cc
+++ b/src/static_handler.cc
@@ -23,6 +23,12 @@ RequestHandler::Status StaticHandler::Init(const std::string& uri_prefix, const 
       return RequestHandler::Error;
     }
   }
+
+  notFoundHandler_ = RequestHandler::CreateByName("NotFoundHandler");
+  if ( ! notFoundHandler_) {
+      std::cerr << "Static handler could not create NotFoundHandler." << std::endl;
+      return RequestHandler::Error;
+  }
   return RequestHandler::OK;
 }
 
@@ -54,8 +60,7 @@ RequestHandler::Status StaticHandler::HandleRequest(const Request& req, Response
 
     switch (err) {
         case FileErr_NoFile:
-            resp->SetStatus(Response::code_404_not_found);
-            return RequestHandler::OK;
+            return notFoundHandler_->HandleRequest(req, resp);
         case FileErr_NoPermission:
             resp->SetStatus(Response::code_401_unauthorized);
             return RequestHandler::OK;
@@ -74,4 +79,10 @@ RequestHandler::Status StaticHandler::HandleRequest(const Request& req, Response
 
     resp->SetStatus(Response::code_500_internal_error);
     return RequestHandler::Error;
+}
+
+StaticHandler::~StaticHandler() {
+    if (notFoundHandler_) {
+        delete notFoundHandler_;
+    }
 }

--- a/src/static_handler.h
+++ b/src/static_handler.h
@@ -9,7 +9,7 @@ class StaticHandler : public RequestHandler {
       virtual Status HandleRequest(const Request& request,
               Response* response);
 
-      virtual ~StaticHandler() = default;
+      virtual ~StaticHandler();
 
       virtual std::string type() const {
           return "StaticHandler";
@@ -19,6 +19,7 @@ class StaticHandler : public RequestHandler {
     protected:
       std::string filebase_;
       std::string path_;
+      RequestHandler* notFoundHandler_;
 };
 
 REGISTER_REQUEST_HANDLER(StaticHandler);


### PR DESCRIPTION
Our spec says that our Static file server should specifically use the NotFoundHandler to handle uri's that don't correspond to files. This change does this.