### PR TITLE
Multithread webserver

### DIFF
--- a/src/webserver.cc
+++ b/src/webserver.cc
@@ -103,7 +103,7 @@ void Webserver::run() {
     for (int i = 0; i < DEFAULT_NUM_THREADS; i++) {
         threads_.emplace_back(std::thread(&Webserver::runThread, this, i));
     }
-    for (int i = 0; i < threads_.size(); i++) {
+    for (int i = 0; i < (int)threads_.size(); i++) {
         threads_[i].join();
         std::unique_lock<std::mutex> lck(mtx_);
         std::cout << "Thread " << i << " exited"  << std::endl;

--- a/src/webserver.h
+++ b/src/webserver.h
@@ -5,7 +5,7 @@
 #include "request_handler.h"
 #include "multimap_counter.h"
 
-const size_t DEFAULT_NUM_THREADS = 8;
+const int DEFAULT_NUM_THREADS = 8;
 
 class Webserver {
     public:

--- a/src/webserver.h
+++ b/src/webserver.h
@@ -1,8 +1,11 @@
 #pragma once
+#include <thread>
 #include <boost/asio.hpp>
 #include "options.h"
 #include "request_handler.h"
 #include "multimap_counter.h"
+
+const size_t DEFAULT_NUM_THREADS = 8;
 
 class Webserver {
     public:
@@ -12,15 +15,16 @@ class Webserver {
 
         Webserver(Options* opt);
         virtual void run();
+        virtual void runThread(int threadIndex);
 
         virtual std::string readStrUntil(
                 boost::asio::ip::tcp::socket& socket,
                 boost::asio::streambuf& buf,
                 const char* termChar,
                 boost::system::error_code& err);
-        virtual void logConnectionDetails(boost::asio::ip::tcp::socket& socket);
+        virtual void logConnectionDetails(int threadIndex, boost::asio::ip::tcp::socket& socket);
         virtual bool acceptConnection(boost::asio::ip::tcp::acceptor& acceptor, boost::asio::ip::tcp::socket& socket);
-        virtual void processConnection(boost::asio::ip::tcp::socket& socket);
+        virtual void processConnection(int threadIndex, boost::asio::ip::tcp::socket& socket);
         virtual std::string processRawRequest(std::string& reqStr);
         virtual void writeResponseString(boost::asio::ip::tcp::socket& socket, const std::string& s);
         virtual RequestHandler* matchRequestWithHandler(const Request& req);
@@ -33,8 +37,13 @@ class Webserver {
         }
 
     private:
-        boost::asio::io_service io_service_;
         Options* opt_;
+        boost::asio::io_service io_service_;
+        boost::asio::ip::tcp::acceptor acceptor_;
+
+        std::mutex mtx_; // guards output, TODO(evan): use thread-safe logging instead
+
         MultiMapCounter<std::string, Response::ResponseCode> counters_;
+        std::vector<std::thread> threads_;
 };
 

--- a/src/webserver.h
+++ b/src/webserver.h
@@ -23,7 +23,7 @@ class Webserver {
                 const char* termChar,
                 boost::system::error_code& err);
         virtual void logConnectionDetails(int threadIndex, boost::asio::ip::tcp::socket& socket);
-        virtual bool acceptConnection(boost::asio::ip::tcp::acceptor& acceptor, boost::asio::ip::tcp::socket& socket);
+        virtual bool acceptConnection(boost::asio::ip::tcp::socket& socket);
         virtual void processConnection(int threadIndex, boost::asio::ip::tcp::socket& socket);
         virtual std::string processRawRequest(std::string& reqStr);
         virtual void writeResponseString(boost::asio::ip::tcp::socket& socket, const std::string& s);
@@ -39,7 +39,7 @@ class Webserver {
     private:
         Options* opt_;
         boost::asio::io_service io_service_;
-        boost::asio::ip::tcp::acceptor acceptor_;
+        std::unique_ptr<boost::asio::ip::tcp::acceptor> acceptor_;
 
         std::mutex mtx_; // guards output, TODO(evan): use thread-safe logging instead
 

--- a/tests/webserver_test.cc
+++ b/tests/webserver_test.cc
@@ -16,8 +16,19 @@ class MockWebserverRun : public Webserver {
     public:
         MOCK_METHOD1(acceptConnection, bool(tcp::socket& sock));
         MOCK_METHOD2(processConnection, void(int threadIndex, tcp::socket& sock));
+        MOCK_METHOD1(runThread, void(int));
 
         MockWebserverRun(Options* opt)
+            : Webserver(opt)
+        { }
+};
+
+class MockWebserverRunThread : public Webserver {
+    public:
+        MOCK_METHOD1(acceptConnection, bool(tcp::socket& sock));
+        MOCK_METHOD2(processConnection, void(int threadIndex, tcp::socket& sock));
+
+        MockWebserverRunThread(Options* opt)
             : Webserver(opt)
         { }
 };
@@ -65,11 +76,26 @@ TEST(WebserverTest, processRawRequest) {
     EXPECT_THAT(resp, HasSubstr(req));
 }
 
+TEST(WebserverTest, startThreads) {
+    Options opts;
+    opts.port = 8080;
+    MockWebserverRun webserver(&opts);
+
+    // TODO: set & use number of threads in options
+    for (int i = 0; i < DEFAULT_NUM_THREADS; i++) {
+        EXPECT_CALL(webserver, runThread(i))
+            .Times(1)
+            .WillOnce(Return());
+    }
+
+    webserver.run();
+}
+
 
 TEST(WebserverTest, acceptConnections) {
     Options opts;
     opts.port = 8080;
-    MockWebserverRun webserver(&opts);
+    MockWebserverRunThread webserver(&opts);
 
     EXPECT_CALL(webserver, acceptConnection(_))
         .Times(3)


### PR DESCRIPTION
Modify webserver to run multiple threads that all accept and respond to connections.

TODO: 
- use number of threads set in config
- use thread-safe logging library
- add integration test to verify effective multithreading