### PR TITLE
Move Coverage info into a separate directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
 	If your build is not working, try cleaning and rebuilding.
 	Make may not always notice dependency changes, especially if changing branches.
 * `make coverage` will run unit tests and track coverage information with gcov.
-	Note: coverage statistics will be printed and coverage files will be placed in the root directory.
-	Note: this will first run `make clean` and rebuild with special flags. After looking at the .gcov files,
-	you should run `make clean` before building again.
+	Note: coverage statistics will be printed and coverage files will be placed in the `coverage` directory.
+	Note: this will first run `make clean` and rebuild with special flags.
+	Note: coverage information applies only to unit tests, not integration tests
 
 ## Running:
 run `./webserver example_config` to run using `example_config`. We recommend you create local config files

--- a/makefile
+++ b/makefile
@@ -62,11 +62,12 @@ integration:
 	tests/integration.py
 
 # Note: coverage requires recompiling everything with new flags
-# after a coverage build, you need to `make clean` again before recompiling.
 coverage: clean
 	@mkdir -p $(COV_DIR)
-	@exec make test EXTRA_FLAGS="$(COVFLAGS)"
+	@exec make --no-print-directory test EXTRA_FLAGS="$(COVFLAGS)"
 	@$(COVCC) $(COVRFLAGS) -s src -o $(OBJ_DIR) $(notdir $(CC_FILES))
+	@mv *.gcov $(COV_DIR)/
+	@exec make -s clean
 
 test-all: test integration
 


### PR DESCRIPTION
After running `make coverage`, move the .gcov files into the coverage directory, then run make clean. This way the build won't be put in an intermediate state with some files built with coverage flags and some not. Also makes it easy to keep track of coverage files.