### PR TITLE
Options thread

### DIFF
--- a/example_config
+++ b/example_config
@@ -1,6 +1,7 @@
 # This is a comment.
 
 port 8080; # This is also a comment.
+threads 8;
 
 path /static StaticHandler {
 	root testFiles1;

--- a/src/options.cc
+++ b/src/options.cc
@@ -93,7 +93,7 @@ bool Options::addThread(std::shared_ptr<NginxConfigStatement> thread_config) {
         std::cerr << "Invalid number of threads.\n";
         return false;
     }
-    this->thread = (unsigned short) std::stoi(thread);
+    this->thread = (unsigned int) std::stoi(thread);
     return true;
 }
 

--- a/src/options.cc
+++ b/src/options.cc
@@ -11,6 +11,7 @@ typedef std::map<string, string> stringMap;
 const int MAX_PORT = 65535;
 const int MIN_PORT = 1024;
 const int MAX_THREADS = 2000; // 32-bit system allows only max 2048 threads
+const int DEFAULT_NUM_THREADS = 8;
 
 const int KEY = 0;
 const int VAL = 1;
@@ -131,9 +132,6 @@ bool Options::loadOptionsFromStream(std::istream* config_file) {
                 return false;
             } else {
                 issetThread = addThread(temp_config);
-                if ( ! issetThread) {
-                    return false;
-                }
             }
         }
 
@@ -163,6 +161,12 @@ bool Options::loadOptionsFromStream(std::istream* config_file) {
     if ( ! issetPort) {
         std::cerr << "A port was not specified.\n";
         return false;
+    }
+
+    if ( ! issetThread) {
+        // for any bad threads numbers, this is default thread #
+        this->thread = DEFAULT_NUM_THREADS;
+        issetThread = true;
     }
 
     if ( ! defaultHandler) {

--- a/src/options.cc
+++ b/src/options.cc
@@ -89,11 +89,11 @@ bool Options::addThread(std::shared_ptr<NginxConfigStatement> thread_config) {
     }
 
     string thread = thread_config->tokens_[VAL];
-    if((unsigned int) std::stoi(thread) > MAX_THREAD || (unsigned int) std::stoi(thread) < 1) {
+    if((unsigned int) std::stoi(thread) > MAX_THREADS || (unsigned int) std::stoi(thread) < 1) {
         std::cerr << "Invalid number of threads.\n";
         return false;
     }
-    this->thread = (unsigned short) std::stoi(port);
+    this->thread = (unsigned short) std::stoi(thread);
     return true;
 }
 
@@ -107,6 +107,7 @@ bool Options::loadOptionsFromStream(std::istream* config_file) {
 
     defaultHandler = nullptr;
     bool issetPort = false;
+    bool issetThread = false;
     for (unsigned int i =0; i < config.statements_.size(); i++) {
         std::shared_ptr<NginxConfigStatement> temp_config = config.statements_[i];
 

--- a/src/options.cc
+++ b/src/options.cc
@@ -10,6 +10,7 @@ typedef std::map<string, string> stringMap;
 
 const int MAX_PORT = 65535;
 const int MIN_PORT = 1024;
+const int MAX_THREADS = 2000; // 32-bit system allows only max 2048 threads
 
 const int KEY = 0;
 const int VAL = 1;
@@ -81,6 +82,21 @@ bool Options::addPort(std::shared_ptr<NginxConfigStatement> port_config) {
     return true;
 }
 
+bool Options::addThread(std::shared_ptr<NginxConfigStatement> thread_config) {
+    if (thread_config->tokens_.size() != STATEMENT_SIZE) {
+        std::cerr << "Incorrect number of tokens. (For threads)\n";
+        return false;
+    }
+
+    string thread = thread_config->tokens_[VAL];
+    if((unsigned int) std::stoi(thread) > MAX_THREAD || (unsigned int) std::stoi(thread) < 1) {
+        std::cerr << "Invalid number of threads.\n";
+        return false;
+    }
+    this->thread = (unsigned short) std::stoi(port);
+    return true;
+}
+
 bool Options::loadOptionsFromStream(std::istream* config_file) {
 
     NginxConfigParser parser;
@@ -106,6 +122,19 @@ bool Options::loadOptionsFromStream(std::istream* config_file) {
                 }
             }
         } 
+
+        // Sets threads.
+        if (temp_config->tokens_.size() > 1 && temp_config->tokens_[KEY] == "threads") {
+            if (issetThread) {
+                std::cerr << "Multiple threads in config file.\n";
+                return false;
+            } else {
+                issetThread = addThread(temp_config);
+                if ( ! issetThread) {
+                    return false;
+                }
+            }
+        }
 
         // Sets handler.
         else if (temp_config->tokens_.size() > 1 && temp_config->tokens_[KEY] == "path") { 

--- a/src/options.cc
+++ b/src/options.cc
@@ -126,12 +126,15 @@ bool Options::loadOptionsFromStream(std::istream* config_file) {
         } 
 
         // Sets threads.
-        if (temp_config->tokens_.size() > 1 && temp_config->tokens_[KEY] == "threads") {
+        else if (temp_config->tokens_.size() > 1 && temp_config->tokens_[KEY] == "threads") {
             if (issetThread) {
                 std::cerr << "Multiple threads in config file.\n";
                 return false;
             } else {
                 issetThread = addThread(temp_config);
+                if( ! issetThread) {
+                    return false;
+                }
             }
         }
 
@@ -164,7 +167,7 @@ bool Options::loadOptionsFromStream(std::istream* config_file) {
     }
 
     if ( ! issetThread) {
-        // for any bad threads numbers, this is default thread #
+        // This is default thread #.
         this->thread = DEFAULT_NUM_THREADS;
         issetThread = true;
     }

--- a/src/options.h
+++ b/src/options.h
@@ -7,13 +7,15 @@
 
 struct Options {
 	unsigned short port;
+        unsigned short thread;
 	std::map<std::string, RequestHandler*> handlerMap;
 	RequestHandler* defaultHandler;
 	bool addHandler(std::string type, std::string path, const NginxConfig& handler_config);
 	bool addPath(std::shared_ptr<NginxConfigStatement> handler_config);
 	bool addDefaultHandler(std::shared_ptr<NginxConfigStatement> handler_config);
 	bool addPort(std::shared_ptr<NginxConfigStatement> port_config);
-	bool loadOptionsFromStream(std::istream* config_file);
+	bool addThread(std::shared_ptr<NginxConfigStatement> thread_config);
+        bool loadOptionsFromStream(std::istream* config_file);
 	bool loadOptionsFromFile(const char* filename);
 	~Options();
 };

--- a/src/options.h
+++ b/src/options.h
@@ -7,7 +7,7 @@
 
 struct Options {
     unsigned short port;
-    unsigned short thread;
+    unsigned int thread;
     std::map<std::string, RequestHandler*> handlerMap;
     RequestHandler* defaultHandler;
     bool addHandler(std::string type, std::string path, const NginxConfig& handler_config);

--- a/src/options.h
+++ b/src/options.h
@@ -6,17 +6,17 @@
 #include "config_parser.h"
 
 struct Options {
-	unsigned short port;
-        unsigned short thread;
-	std::map<std::string, RequestHandler*> handlerMap;
-	RequestHandler* defaultHandler;
-	bool addHandler(std::string type, std::string path, const NginxConfig& handler_config);
-	bool addPath(std::shared_ptr<NginxConfigStatement> handler_config);
-	bool addDefaultHandler(std::shared_ptr<NginxConfigStatement> handler_config);
-	bool addPort(std::shared_ptr<NginxConfigStatement> port_config);
-	bool addThread(std::shared_ptr<NginxConfigStatement> thread_config);
-        bool loadOptionsFromStream(std::istream* config_file);
-	bool loadOptionsFromFile(const char* filename);
-	~Options();
+    unsigned short port;
+    unsigned short thread;
+    std::map<std::string, RequestHandler*> handlerMap;
+    RequestHandler* defaultHandler;
+    bool addHandler(std::string type, std::string path, const NginxConfig& handler_config);
+    bool addPath(std::shared_ptr<NginxConfigStatement> handler_config);
+    bool addDefaultHandler(std::shared_ptr<NginxConfigStatement> handler_config);
+    bool addPort(std::shared_ptr<NginxConfigStatement> port_config);
+    bool addThread(std::shared_ptr<NginxConfigStatement> thread_config);
+    bool loadOptionsFromStream(std::istream* config_file);
+    bool loadOptionsFromFile(const char* filename);
+    ~Options();
 };
 

--- a/src/webserver.cc
+++ b/src/webserver.cc
@@ -100,7 +100,7 @@ bool Webserver::acceptConnection(tcp::socket& socket) {
 void Webserver::run() {
     acceptor_ = std::unique_ptr<tcp::acceptor>(new tcp::acceptor(io_service_, tcp::endpoint(tcp::v4(), opt_->port)));
 
-    for (int i = 0; i < DEFAULT_NUM_THREADS; i++) {
+    for (int i = 0; i < opt_->thread; i++) {
         threads_.emplace_back(std::thread(&Webserver::runThread, this, i));
     }
     for (int i = 0; i < (int)threads_.size(); i++) {

--- a/src/webserver.cc
+++ b/src/webserver.cc
@@ -100,7 +100,7 @@ bool Webserver::acceptConnection(tcp::socket& socket) {
 void Webserver::run() {
     acceptor_ = std::unique_ptr<tcp::acceptor>(new tcp::acceptor(io_service_, tcp::endpoint(tcp::v4(), opt_->port)));
 
-    for (int i = 0; i < opt_->thread; i++) {
+    for (int i = 0; i < (int)opt_->thread; i++) {
         threads_.emplace_back(std::thread(&Webserver::runThread, this, i));
     }
     for (int i = 0; i < (int)threads_.size(); i++) {

--- a/src/webserver.h
+++ b/src/webserver.h
@@ -5,8 +5,6 @@
 #include "request_handler.h"
 #include "multimap_counter.h"
 
-const int DEFAULT_NUM_THREADS = 8;
-
 class Webserver {
     public:
         // faux singleton: Webserver::instance stores the most recently constructed webserver.

--- a/tests/options_test.cc
+++ b/tests/options_test.cc
@@ -4,12 +4,12 @@
 
 // PORT TESTS
 TEST(OptionsLoadStreamPortTest, BoundaryCases) {
-	std::stringstream port0("port 0;");
-	std::stringstream port1023("port 1023;");
-	std::stringstream port1024("port 1024;");
-	std::stringstream port8080("port 8080;");
-	std::stringstream port65535("port 65535;");
-	std::stringstream port65545("port 65545;");
+	std::stringstream port0("port 0; thread 1;");
+	std::stringstream port1023("port 1023; thread 1;");
+	std::stringstream port1024("port 1024; thread 1;");
+	std::stringstream port8080("port 8080; thread 1;");
+	std::stringstream port65535("port 65535; thread 1;");
+	std::stringstream port65545("port 65545; thread 1;");
 
 	Options opt;
 
@@ -57,6 +57,15 @@ TEST(OptionsLoadFileTest, NoFileExists) {
 TEST(OptionsLoadFileTest, ASimpleFile) {
 	Options opt;
 	EXPECT_TRUE(opt.loadOptionsFromFile("example_config"));
+}
+//THREADS TESTS
+TEST(OptionsLoadStreamThreadTest, badNumThreads) {
+	std::stringstream threads("port 8080; threads 0;");
+        std::stringstream threads2("port 8080; threads 2001");
+
+	Options opt;
+	EXPECT_FALSE(opt.loadOptionsFromStream(&threads));
+	EXPECT_FALSE(opt.loadOptionsFromStream(&threads2));
 }
 
 //HANDLERS TESTS

--- a/tests/options_test.cc
+++ b/tests/options_test.cc
@@ -2,23 +2,30 @@
 #include "options.h"
 #include <sstream>
 
+const int DEFAULT_NUM_THREADS = 8;
+
 // PORT TESTS
 TEST(OptionsLoadStreamPortTest, BoundaryCases) {
-	std::stringstream port0("port 0; thread 1;");
-	std::stringstream port1023("port 1023; thread 1;");
-	std::stringstream port1024("port 1024; thread 1;");
-	std::stringstream port8080("port 8080; thread 1;");
-	std::stringstream port65535("port 65535; thread 1;");
-	std::stringstream port65545("port 65545; thread 1;");
+	std::stringstream port0("port 0;");
+	std::stringstream port1023("port 1023;");
+	std::stringstream port1024("port 1024;");
+	std::stringstream port8080("port 8080;");
+	std::stringstream port65535("port 65535;");
+	std::stringstream port65545("port 65545;");
 
 	Options opt;
+	Options opt2;
+	Options opt3;
+	Options opt4;
+	Options opt5;
+	Options opt6;
 
 	EXPECT_FALSE(opt.loadOptionsFromStream(&port0));
-	EXPECT_FALSE(opt.loadOptionsFromStream(&port1023));
-	EXPECT_TRUE(opt.loadOptionsFromStream(&port1024));
-	EXPECT_TRUE(opt.loadOptionsFromStream(&port8080));
-	EXPECT_TRUE(opt.loadOptionsFromStream(&port65535));
-	EXPECT_FALSE(opt.loadOptionsFromStream(&port65545));
+	EXPECT_FALSE(opt2.loadOptionsFromStream(&port1023));
+	EXPECT_TRUE(opt3.loadOptionsFromStream(&port1024));
+	EXPECT_TRUE(opt4.loadOptionsFromStream(&port8080));
+	EXPECT_TRUE(opt5.loadOptionsFromStream(&port65535));
+	EXPECT_FALSE(opt6.loadOptionsFromStream(&port65545));
 }
 
 TEST(OptionsLoadStreamPortTest, NoPort) {
@@ -61,11 +68,25 @@ TEST(OptionsLoadFileTest, ASimpleFile) {
 //THREADS TESTS
 TEST(OptionsLoadStreamThreadTest, badNumThreads) {
 	std::stringstream threads("port 8080; threads 0;");
-        std::stringstream threads2("port 8080; threads 2001");
+        std::stringstream threads2("port 8080; threads 2001;");
 
 	Options opt;
 	EXPECT_FALSE(opt.loadOptionsFromStream(&threads));
-	EXPECT_FALSE(opt.loadOptionsFromStream(&threads2));
+        EXPECT_FALSE(opt.loadOptionsFromStream(&threads2));
+}
+TEST(OptionsLoadStreamThreadTest, noThreads) {
+	std::stringstream threads("port 8080;");
+
+	Options opt;
+	EXPECT_TRUE(opt.loadOptionsFromStream(&threads));
+	EXPECT_EQ(opt.thread, DEFAULT_NUM_THREADS);
+}
+TEST(OptionsLoadStreamThreadTest, simpleThreads) {
+	std::stringstream threads("port 8080; threads 4;");
+
+	Options opt;
+	EXPECT_TRUE(opt.loadOptionsFromStream(&threads));
+	EXPECT_EQ(opt.thread, 4);
 }
 
 //HANDLERS TESTS

--- a/tests/webserver_test.cc
+++ b/tests/webserver_test.cc
@@ -79,10 +79,10 @@ TEST(WebserverTest, processRawRequest) {
 TEST(WebserverTest, startThreads) {
     Options opts;
     opts.port = 8080;
+    opts.thread = 8;
     MockWebserverRun webserver(&opts);
 
-    // TODO: set & use number of threads in options
-    for (int i = 0; i < DEFAULT_NUM_THREADS; i++) {
+    for (int i = 0; i < opts.thread; i++) {
         EXPECT_CALL(webserver, runThread(i))
             .Times(1)
             .WillOnce(Return());


### PR DESCRIPTION
Allows threads to be a part of options struct and be assigned through config file
- no tests fails (updated)
TODO:
- why is travis failing?
